### PR TITLE
fix: Correct model output shape for node-level predictions

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,379 @@
+import pandas as pd
+import numpy as np
+import torch
+from torch_geometric.data import Data
+from torch_geometric.nn import knn_graph
+from torch_geometric.transforms import AddLaplacianEigenvectorPE
+import torch_geometric.utils as pyg_utils # Added for to_undirected
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.impute import SimpleImputer
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+import os # For checking file existence
+
+def load_and_preprocess_data(csv_path, preprocessor=None, fit_preprocessor=False, target_cols=None, k_neighbors=10):
+    """
+    Loads data from CSV, preprocesses features, and constructs a graph.
+
+    Args:
+        csv_path (str): Path to the CSV file.
+        preprocessor (ColumnTransformer, optional): Fitted preprocessor.
+                                                   If None and fit_preprocessor is True, a new one is created and fitted.
+        fit_preprocessor (bool): If True, fit a new preprocessor or refit the provided one.
+        target_cols (list, optional): List of target column names to extract.
+        k_neighbors (int): Number of neighbors for k-NN graph.
+
+    Returns:
+        tuple: (torch_geometric.data.Data, pd.DataFrame or None, ColumnTransformer or None)
+               - Graph data object
+               - Target DataFrame (if target_cols provided)
+               - Fitted preprocessor (if fit_preprocessor is True)
+    """
+    print(f"\n--- Starting data processing for: {csv_path} ---")
+    if not os.path.exists(csv_path):
+        print(f"ERROR: File not found at {csv_path}")
+        if fit_preprocessor:
+            return None, None, None
+        else:
+            return None, None
+
+    df = pd.read_csv(csv_path)
+    print(f"Initial data shape: {df.shape}")
+    print(f"Initial columns: {df.columns.tolist()}")
+    print(f"Data types before any processing:\n{df.dtypes}")
+
+    # --- Basic Cleaning & Initial Feature Engineering ---
+    # 1. OutcomeType to numeric
+    if 'outcomeType' in df.columns:
+        print("Processing 'outcomeType'...")
+        df['outcomeType'] = df['outcomeType'].replace({'Survival': 0, 'Death': 1})
+        print(f"'outcomeType' unique values after mapping: {df['outcomeType'].unique()}")
+
+    # 2. Handle 'Not applicable' and other string NaNs across likely numeric/categorical columns
+    cols_to_check_na = ['glasgowScale', 'hematocrit', 'hemoglobin', 'leucocitos',
+                        'lymphocytes', 'urea', 'creatinine', 'platelets', 'diuresis', 'patientAge']
+    print("Converting 'Not applicable' and similar to NaN for numeric columns...")
+    for col in cols_to_check_na:
+        if col in df.columns:
+            original_na_count = df[col].isna().sum()
+            df[col] = df[col].replace(['Not applicable', 'NA', 'NaN', 'nan', 'Not Applicable', 'Não aplicavel', 'Not informed'], np.nan)
+            df[col] = pd.to_numeric(df[col], errors='coerce')
+            new_na_count = df[col].isna().sum()
+            print(f"Column '{col}': {new_na_count - original_na_count} new NaNs from string replacement. Total NaNs: {new_na_count}")
+
+    # 3. Blood Pressure: Parse 'blodPressure'
+    if 'blodPressure' in df.columns:
+        print("Parsing 'blodPressure'...")
+        df['blodPressure_str'] = df['blodPressure'].astype(str).str.lower()
+        bp_split = df['blodPressure_str'].str.split('x', expand=True)
+
+        df['systolicPressure'] = pd.to_numeric(bp_split[0], errors='coerce')
+        if bp_split.shape[1] > 1:
+            # Clean common non-numeric parts like 'mmhg'
+            df['diastolicPressure'] = pd.to_numeric(bp_split[1].str.replace(r'[^0-9\.]', '', regex=True), errors='coerce')
+        else:
+            df['diastolicPressure'] = np.nan
+
+        df.drop(['blodPressure', 'blodPressure_str'], axis=1, inplace=True)
+        print("Created 'systolicPressure' and 'diastolicPressure'. Dropped 'blodPressure'.")
+        print(f"NaNs in systolicPressure: {df['systolicPressure'].isna().sum()}")
+        print(f"NaNs in diastolicPressure: {df['diastolicPressure'].isna().sum()}")
+
+    # 4. ICD Code: Extract first letter
+    if 'icdCode' in df.columns:
+        print("Processing 'icdCode' into 'icdCode_group'...")
+        df['icdCode_group'] = df['icdCode'].astype(str).str[0].fillna('Unknown')
+        df['icdCode_group'] = df['icdCode_group'].replace('nan', 'Unknown') # Handle 'nan' string
+        print(f"'icdCode_group' unique values: {df['icdCode_group'].unique()}")
+
+    # Drop original date columns and other specified columns
+    cols_to_drop_initial = ['requestDate', 'admissionDate', 'icdCode']
+    # requestBedType might not be in test data, handle conditionally
+    if 'requestBedType' in df.columns and 'requestBedType' in cols_to_drop_initial:
+        cols_to_drop_initial.append('requestBedType')
+
+    df.drop(columns=[col for col in cols_to_drop_initial if col in df.columns], inplace=True, errors='ignore')
+    print(f"Dropped initial columns. Remaining columns: {df.columns.tolist()}")
+
+    # --- Define Feature Columns (after initial processing) ---
+    temp_target_cols = target_cols if target_cols else []
+
+    # Identify numerical features robustly
+    numerical_features = []
+    for col in df.columns:
+        if col not in temp_target_cols:
+            try:
+                _ = pd.to_numeric(df[col])
+                if df[col].dtype != 'object' and df[col].dtype != 'bool': # Exclude already encoded or boolean if any
+                     if not all(df[col].dropna().isin([0, 1])): # Exclude binary columns that might be categorical
+                        numerical_features.append(col)
+            except (ValueError, TypeError):
+                continue
+
+    # Identify categorical features (non-numeric and not targets)
+    categorical_features = [col for col in df.select_dtypes(include=['object', 'category']).columns if col not in temp_target_cols]
+    # Add icdCode_group if it's not already picked up and exists
+    if 'icdCode_group' in df.columns and 'icdCode_group' not in categorical_features and 'icdCode_group' not in temp_target_cols:
+        categorical_features.append('icdCode_group')
+
+    # Ensure no overlap and remove any misclassified binary numericals that are actually categorical representations
+    # For example, if 'patientGender' was 0/1 already
+    potential_binary_cats = [col for col in numerical_features if df[col].dropna().isin([0,1]).all() and df[col].nunique() <=2]
+    if potential_binary_cats:
+        print(f"Potential binary columns in numerical_features to re-evaluate: {potential_binary_cats}")
+        # Decision: For now, keep them as numerical if they passed the numeric checks.
+        # One-hot encoding will handle distinct values if they are truly categorical.
+
+    print(f"Identified Numerical Features: {numerical_features}")
+    print(f"Identified Categorical Features: {categorical_features}")
+
+    # Extract targets if specified
+    if target_cols:
+        targets_df = df[target_cols].copy()
+        print(f"Targets extracted. Shape: {targets_df.shape}")
+    else:
+        targets_df = None
+        print("No target columns specified.")
+
+    feature_columns = numerical_features + categorical_features
+    if not feature_columns:
+        print("ERROR: No feature columns identified. Check data and feature definitions.")
+        if fit_preprocessor:
+            return None, None, None
+        else:
+            return None, None
+
+    df_features = df[feature_columns].copy()
+    print(f"Shape of DataFrame being sent to preprocessor: {df_features.shape}")
+
+
+    # --- Preprocessing Pipelines ---
+    if preprocessor is None:
+        print("Preprocessor is None. Creating and fitting a new one.")
+        numeric_transformer = Pipeline(steps=[
+            ('imputer', SimpleImputer(strategy='median')),
+            ('scaler', StandardScaler())
+        ])
+
+        categorical_transformer = Pipeline(steps=[
+            ('imputer', SimpleImputer(strategy='constant', fill_value='missing')),
+            ('onehot', OneHotEncoder(handle_unknown='ignore', sparse_output=False))
+        ])
+
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ('num', numeric_transformer, numerical_features),
+                ('cat', categorical_transformer, categorical_features)
+            ],
+            remainder='drop' # Drop any columns not specified
+        )
+
+        # Fit the preprocessor
+        print(f"Fitting preprocessor on features: {feature_columns}")
+        df_processed_np = preprocessor.fit_transform(df_features)
+        print(f"Data processed. Shape after preprocessor fit_transform: {df_processed_np.shape}")
+
+        try:
+            onehot_feature_names = preprocessor.named_transformers_['cat'].named_steps['onehot'].get_feature_names_out(categorical_features)
+            all_feature_names = numerical_features + list(onehot_feature_names)
+            print(f"Total features after one-hot encoding: {len(all_feature_names)}")
+        except Exception as e:
+            print(f"Could not get feature names out from one-hot encoder: {e}")
+            all_feature_names = []
+
+
+    elif fit_preprocessor: # Refit the provided preprocessor
+        print("Refitting the provided preprocessor.")
+        df_processed_np = preprocessor.fit_transform(df_features)
+        print(f"Data processed. Shape after preprocessor fit_transform: {df_processed_np.shape}")
+    else: # Use the already fitted preprocessor
+        print("Using provided pre-fitted preprocessor.")
+        df_processed_np = preprocessor.transform(df_features)
+        print(f"Data processed. Shape after preprocessor transform: {df_processed_np.shape}")
+
+    # --- Create PyTorch Geometric Data object ---
+    x = torch.tensor(df_processed_np, dtype=torch.float)
+    print(f"Node features tensor 'x' created with shape: {x.shape}")
+
+    edge_index = knn_graph(x, k=k_neighbors, batch=None, loop=False)
+    print(f"Edge index created with shape: {edge_index.shape}")
+
+    graph_data = Data(x=x, edge_index=edge_index)
+
+    # Add Laplacian Positional Encoding
+    lap_pe_k = 8 # Default k for LapPE, can be parameterized in load_and_preprocess_data if needed
+    # Check if graph_data has nodes and edges before applying transform
+    if graph_data.num_nodes > 0 and graph_data.num_edges > 0 :
+        print(f"Applying AddLaplacianEigenvectorPE with k={lap_pe_k}")
+        # is_undirected needs to be True if the graph is meant to be undirected for PE calculation
+        # PyG's knn_graph by default creates a directed graph (source to target for k-nearest).
+        # For LapPE, an undirected graph's Laplacian is typically used.
+        # We can make it undirected, or use is_undirected=False if the specific PE variant handles directed.
+        # Let's make it undirected for standard LapPE.
+        graph_data.edge_index = pyg_utils.to_undirected(graph_data.edge_index, num_nodes=graph_data.num_nodes)
+
+        lap_pe_transform = AddLaplacianEigenvectorPE(k=lap_pe_k, attr_name='lap_pe', is_undirected=True)
+        try:
+            graph_data = lap_pe_transform(graph_data)
+            print(f"Laplacian PE added. Shape: {graph_data.lap_pe.shape}")
+        except Exception as e:
+            print(f"Could not apply AddLaplacianEigenvectorPE: {e}. Num_nodes: {graph_data.num_nodes}, Num_edges: {graph_data.edge_index.size(1)}")
+            # Fallback: add zero PE if transform fails
+            graph_data.lap_pe = torch.zeros((graph_data.num_nodes, lap_pe_k), dtype=torch.float)
+            print(f"Added zero LapPE as fallback. Shape: {graph_data.lap_pe.shape}")
+    elif graph_data.num_nodes > 0 : # Nodes exist, but no edges from k-NN (e.g. k too small or isolated nodes)
+        print(f"Skipping AddLaplacianEigenvectorPE as num_edges is 0. Adding zero LapPE.")
+        graph_data.lap_pe = torch.zeros((graph_data.num_nodes, lap_pe_k), dtype=torch.float)
+        print(f"Added zero LapPE. Shape: {graph_data.lap_pe.shape}")
+    else: # No nodes
+        print("Skipping AddLaplacianEigenvectorPE as there are no nodes in the graph.")
+
+
+    if targets_df is not None:
+        print("Adding target variables to graph_data object...")
+        if 'outcomeType' in targets_df.columns:
+            y_mortality = torch.tensor(targets_df['outcomeType'].values, dtype=torch.float) # BCEWithLogitsLoss expects float
+            graph_data.y_mortality = y_mortality.unsqueeze(1) # Ensure shape [N, 1]
+            print(f"y_mortality added. Shape: {graph_data.y_mortality.shape}")
+        if 'lengthofStay' in targets_df.columns:
+            y_los = torch.tensor(targets_df['lengthofStay'].values, dtype=torch.float)
+            graph_data.y_los = y_los.unsqueeze(1) # Ensure shape [N, 1]
+            print(f"y_los added. Shape: {graph_data.y_los.shape}")
+
+    print(f"Final graph object: {graph_data}")
+    print(f"--- Finished data processing for: {csv_path} ---\n")
+
+    if fit_preprocessor:
+        return graph_data, targets_df, preprocessor
+    else:
+        return graph_data, targets_df
+
+
+if __name__ == '__main__':
+    # Create dummy data files if they don't exist, for local testing.
+    # This part is for local execution and won't run in the agent's sandbox.
+
+    dummy_data_rows = 100
+    base_columns = [
+        'requestDate', 'requestType', 'requestBedType', 'admissionDate', 'admissionBedType',
+        'admissionHealthUnit', 'patientGender', 'patientAge', 'patientFfederalUnit', 'icdCode',
+        'blodPressure', 'glasgowScale', 'hematocrit', 'hemoglobin', 'leucocitos',
+        'lymphocytes', 'urea', 'creatinine', 'platelets', 'diuresis',
+        'outcomeType', 'lengthofStay'
+    ]
+
+    sample_data = {
+        'requestDate': pd.to_datetime('2023-01-01') + pd.to_timedelta(np.random.randint(0, 365, dummy_data_rows), unit='D'),
+        'requestType': np.random.choice(['Adult', 'Pediatric', 'Geriatric'], dummy_data_rows),
+        'requestBedType': np.random.choice(['UCI', 'Ward', 'Emergency'], dummy_data_rows),
+        'admissionDate': pd.to_datetime('2023-01-01') + pd.to_timedelta(np.random.randint(0, 365, dummy_data_rows), unit='D'),
+        'admissionBedType': np.random.choice(['UCI', 'Ward', 'Semi-UCI'], dummy_data_rows),
+        'admissionHealthUnit': np.random.choice(['Unit A', 'Unit B', 'Unit C', '2ª MOSSORÓ'], dummy_data_rows),
+        'patientGender': np.random.choice(['M', 'F'], dummy_data_rows),
+        'patientAge': np.random.randint(1, 100, dummy_data_rows),
+        'patientFfederalUnit': np.random.choice(['RN', 'SP', 'MG', 'BA'], dummy_data_rows),
+        'icdCode': [f"{chr(np.random.randint(65, 91))}{np.random.randint(0,10)}{np.random.randint(0,10)}.{np.random.randint(0,10)}" for _ in range(dummy_data_rows)],
+        'blodPressure': [f"{np.random.randint(90, 180)}x{np.random.randint(50, 100)}" if np.random.rand() > 0.1 else f"{np.random.randint(90, 180)}X{np.random.randint(50, 100)}MMHG" for _ in range(dummy_data_rows)],
+        'glasgowScale': [str(np.random.randint(3, 16)) if np.random.rand() > 0.1 else 'Not applicable' for _ in range(dummy_data_rows)],
+        'hematocrit': np.random.uniform(20, 55, dummy_data_rows).round(1),
+        'hemoglobin': np.random.uniform(7, 18, dummy_data_rows).round(1),
+        'leucocitos': np.random.uniform(1, 30, dummy_data_rows).round(2) * 1000,
+        'lymphocytes': np.random.randint(5, 70, dummy_data_rows),
+        'urea': np.random.uniform(10, 200, dummy_data_rows).round(2),
+        'creatinine': np.random.uniform(0.5, 10, dummy_data_rows).round(2),
+        'platelets': np.random.randint(20, 600, dummy_data_rows),
+        'diuresis': [str(np.random.randint(100, 3000)) if np.random.rand() > 0.05 else '9999' for _ in range(dummy_data_rows)],
+        'outcomeType': np.random.choice(['Survival', 'Death'], dummy_data_rows, p=[0.8, 0.2]),
+        'lengthofStay': np.random.randint(0, 100, dummy_data_rows)
+    }
+    sample_df = pd.DataFrame(sample_data)
+
+    # Create dummy files if they don't exist
+    if not os.path.exists('data'):
+        os.makedirs('data')
+
+    if not os.path.exists('data/trainData.csv'):
+        print("Creating dummy trainData.csv for local testing.")
+        sample_df.sample(frac=0.7, random_state=42).to_csv('data/trainData.csv', index=False)
+
+    if not os.path.exists('data/valData.csv'):
+        print("Creating dummy valData.csv for local testing.")
+        sample_df.sample(frac=0.15, random_state=1).to_csv('data/valData.csv', index=False)
+
+    if not os.path.exists('data/testData.csv'):
+        print("Creating dummy testData.csv for local testing.")
+        dummy_test_df = sample_df.sample(frac=0.15, random_state=2).drop(columns=['outcomeType', 'lengthofStay'])
+        dummy_test_df.to_csv('data/testData.csv', index=False)
+
+    print("Starting example usage of load_and_preprocess_data...")
+
+    print("\n--- Processing training data (fitting preprocessor) ---")
+    train_graph_data, train_targets, fitted_preprocessor = load_and_preprocess_data(
+        'data/trainData.csv',
+        fit_preprocessor=True,
+        target_cols=['outcomeType', 'lengthofStay'],
+        k_neighbors=5 # Smaller k for smaller dummy data
+    )
+    if train_graph_data:
+        print(f"Train graph: {train_graph_data}")
+        if train_targets is not None:
+            print(f"Train targets head:\n{train_targets.head()}")
+            print(f"Train y_mortality sample (from graph): {train_graph_data.y_mortality[:5] if hasattr(train_graph_data, 'y_mortality') else 'Not present'}")
+            print(f"Train y_los sample (from graph): {train_graph_data.y_los[:5] if hasattr(train_graph_data, 'y_los') else 'Not present'}")
+        if fitted_preprocessor:
+            print("Preprocessor fitted successfully.")
+    else:
+        print("Failed to process training data.")
+
+    if fitted_preprocessor:
+        print("\n--- Processing validation data (using fitted preprocessor) ---")
+        val_graph_data, val_targets = load_and_preprocess_data(
+            'data/valData.csv',
+            preprocessor=fitted_preprocessor,
+            fit_preprocessor=False,
+            target_cols=['outcomeType', 'lengthofStay'],
+            k_neighbors=5
+        )
+        if val_graph_data:
+            print(f"Validation graph: {val_graph_data}")
+            if val_targets is not None:
+                print(f"Validation targets head:\n{val_targets.head()}")
+        else:
+            print("Failed to process validation data.")
+
+        if os.path.exists('data/testData.csv'):
+            print("\n--- Processing test data (no targets, using fitted preprocessor) ---")
+            test_graph_data, _ = load_and_preprocess_data(
+                'data/testData.csv',
+                preprocessor=fitted_preprocessor,
+                fit_preprocessor=False,
+                k_neighbors=5
+            )
+            if test_graph_data:
+                print(f"Test graph: {test_graph_data}")
+            else:
+                print("Failed to process test data.")
+        else:
+            print("\n--- Skipping test data processing (testData.csv not found) ---")
+
+        print("\n--- Verifying preprocessor content ---")
+        num_feats_idx = 0
+        cat_feats_idx = 1
+        if not fitted_preprocessor.transformers_[0][2]: # if numerical_features was empty
+            cat_feats_idx = 0
+
+        print(f"Numerical features in preprocessor: {fitted_preprocessor.transformers_[num_feats_idx][2] if len(fitted_preprocessor.transformers_) > num_feats_idx and fitted_preprocessor.transformers_[num_feats_idx][0]=='num' else 'None or wrong index'}")
+        if len(fitted_preprocessor.transformers_) > cat_feats_idx and fitted_preprocessor.transformers_[cat_feats_idx][0]=='cat':
+             print(f"Categorical features in preprocessor: {fitted_preprocessor.transformers_[cat_feats_idx][2]}")
+             try:
+                onehot_cols = fitted_preprocessor.named_transformers_['cat'].named_steps['onehot'].get_feature_names_out(fitted_preprocessor.transformers_[cat_feats_idx][2])
+                print(f"OneHotEncoder generated columns example: {list(onehot_cols[:5])} ... (total {len(onehot_cols)})")
+             except Exception as e:
+                print(f"Could not get feature names from OneHotEncoder: {e}")
+        else:
+            print("Categorical transformer not found or at unexpected index.")
+
+    else:
+        print("Preprocessor fitting failed, skipping dependent steps.")
+
+    print("\nData processing utility script example usage finished.")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,257 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch_geometric.nn as pyg_nn
+from torch_geometric.data import Data
+# AddLaplacianEigenvectorPE is used in data_utils, not directly here usually
+
+class GPSLayer(nn.Module):
+    """
+    A single GraphGPS layer, which typically combines a message passing GNN layer,
+    a local Transformer-style attention (e.g., MHA on nodes), and positional encodings.
+    This is a simplified placeholder. A full GRIT/SAN implementation would be more complex.
+    """
+    def __init__(self, dim_h, num_heads=4, dropout=0.1, attention_dropout=0.1, local_gnn_type='GCNConv'):
+        super().__init__()
+        self.dim_h = dim_h
+        self.num_heads = num_heads
+
+        # Local GNN part (Message Passing)
+        if local_gnn_type == 'GCNConv':
+            self.local_gnn = pyg_nn.GCNConv(dim_h, dim_h)
+        elif local_gnn_type == 'GINConv':
+            gin_nn = nn.Sequential(nn.Linear(dim_h, dim_h), nn.ReLU(), nn.Linear(dim_h, dim_h))
+            self.local_gnn = pyg_nn.GINConv(gin_nn)
+        elif local_gnn_type == 'GATConv': # Default for predictors
+            self.local_gnn = pyg_nn.GATConv(dim_h, dim_h, heads=num_heads, concat=False, dropout=attention_dropout)
+        else:
+            raise ValueError(f"Unsupported local_gnn_type: {local_gnn_type}")
+
+        # Global Attention part (Self-Attention on nodes)
+        self.self_attn = nn.MultiheadAttention(dim_h, num_heads, dropout=attention_dropout, batch_first=True)
+
+        self.norm1_local = nn.LayerNorm(dim_h)
+        self.norm1_attn = nn.LayerNorm(dim_h) # Changed from norm1_local to norm1_attn
+        self.dropout_local = nn.Dropout(dropout)
+        self.dropout_attn = nn.Dropout(dropout)
+
+        self.ffn = nn.Sequential(
+            nn.Linear(dim_h, dim_h * 2),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim_h * 2, dim_h)
+        )
+        self.norm2 = nn.LayerNorm(dim_h)
+        self.dropout_ffn = nn.Dropout(dropout)
+
+    def forward(self, x, edge_index):
+        x_res_local = x
+        x_local_out = self.local_gnn(x, edge_index)
+        x_local_out = self.dropout_local(x_local_out)
+        x = x_res_local + x_local_out
+        x = self.norm1_local(x)
+
+        x_res_attn = x
+        # MultiheadAttention expects shape (N, L, E) or (L, N, E) if batch_first=False
+        # Here, num_nodes is L (sequence length), N is batch_size (1 for a single graph)
+        x_attn_input = x.unsqueeze(0) # Shape: [1, num_nodes, dim_h]
+        x_attn, _ = self.self_attn(x_attn_input, x_attn_input, x_attn_input)
+        x_attn = x_attn.squeeze(0) # Shape: [num_nodes, dim_h]
+        x_attn = self.dropout_attn(x_attn)
+        x = x_res_attn + x_attn
+        x = self.norm1_attn(x) # Corrected norm application
+
+        x_res_ffn = x
+        x_ffn_out = self.ffn(x)
+        x_ffn_out = self.dropout_ffn(x_ffn_out)
+        x = x_res_ffn + x_ffn_out
+        x = self.norm2(x)
+
+        return x
+
+class GraphGPS(nn.Module):
+    def __init__(self, dim_in, dim_h, dim_out_graph_level, num_layers, num_heads, # dim_out_graph_level for graph-level tasks
+                 lap_pe_dim, sign_pe_dim, # These are the dimensions of PE features *provided in the Data object*
+                 dropout=0.1, local_gnn_type='GCNConv', pool_type='mean'):
+        super().__init__()
+        self.dim_h = dim_h
+        self.lap_pe_dim = lap_pe_dim
+        self.sign_pe_dim = sign_pe_dim
+
+        # The atom_encoder's input dimension depends on raw features + PEs that will be concatenated
+        effective_atom_encoder_dim_in = dim_in
+        if self.lap_pe_dim > 0:
+            effective_atom_encoder_dim_in += self.lap_pe_dim
+        if self.sign_pe_dim > 0: # Placeholder for SignNet feature dimension
+            effective_atom_encoder_dim_in += self.sign_pe_dim
+
+        self.atom_encoder = nn.Linear(effective_atom_encoder_dim_in, dim_h)
+
+        self.gps_layers = nn.ModuleList()
+        for _ in range(num_layers):
+            self.gps_layers.append(GPSLayer(dim_h, num_heads, dropout, dropout, local_gnn_type))
+
+        self.pool_type = pool_type
+        if self.pool_type: # Only define pool and graph-level head if pooling is specified
+            if pool_type == 'mean':
+                self.pool = pyg_nn.global_mean_pool
+            elif pool_type == 'add':
+                self.pool = pyg_nn.global_add_pool
+            elif pool_type == 'max':
+                self.pool = pyg_nn.global_max_pool
+            else:
+                raise ValueError(f"Unsupported pool_type: {pool_type}")
+            self.graph_level_output_head = nn.Linear(dim_h, dim_out_graph_level)
+        else: # No pooling, implies node-level tasks handled by derived classes
+            self.pool = None
+            self.graph_level_output_head = None
+
+
+    def forward(self, data: Data):
+        x, edge_index, batch = data.x, data.edge_index, data.batch
+
+        pe_features_list = []
+        if self.lap_pe_dim > 0 and hasattr(data, 'lap_pe') and data.lap_pe is not None:
+            # Ensure lap_pe has the expected dimension self.lap_pe_dim
+            if data.lap_pe.shape[1] != self.lap_pe_dim:
+                 raise ValueError(f"data.lap_pe dim {data.lap_pe.shape[1]} != model lap_pe_dim {self.lap_pe_dim}")
+            pe_features_list.append(data.lap_pe)
+
+        if self.sign_pe_dim > 0 and hasattr(data, 'sign_pe') and data.sign_pe is not None:
+            if data.sign_pe.shape[1] != self.sign_pe_dim:
+                 raise ValueError(f"data.sign_pe dim {data.sign_pe.shape[1]} != model sign_pe_dim {self.sign_pe_dim}")
+            pe_features_list.append(data.sign_pe)
+
+        if pe_features_list:
+            x = torch.cat([x] + pe_features_list, dim=-1)
+
+        x = self.atom_encoder(x) # Now x has dim_h
+
+        for layer in self.gps_layers:
+            x = layer(x, edge_index) # Node embeddings after GPS layers
+
+        # If pooling is defined (for graph-level tasks), apply it and the graph-level head
+        if self.pool is not None and self.graph_level_output_head is not None:
+            if batch is None:
+                batch = torch.zeros(x.size(0), dtype=torch.long, device=x.device)
+            graph_emb = self.pool(x, batch)
+            out = self.graph_level_output_head(graph_emb)
+            return out # Graph-level output
+        else:
+            # For node-level tasks, derived classes will use these node embeddings
+            return x # Node embeddings, shape [num_nodes, dim_h]
+
+
+class MortalityPredictor(GraphGPS):
+    def __init__(self, dim_in, dim_h, num_layers, num_heads, lap_pe_dim, sign_pe_dim, dropout=0.1):
+        # dim_out_graph_level for GraphGPS base is not used as pool_type is None
+        super().__init__(dim_in=dim_in, dim_h=dim_h, dim_out_graph_level=1,
+                         num_layers=num_layers, num_heads=num_heads,
+                         lap_pe_dim=lap_pe_dim, sign_pe_dim=sign_pe_dim,
+                         dropout=dropout, local_gnn_type='GATConv', pool_type=None) # No global pooling
+        self.node_level_output_head = nn.Linear(dim_h, 1) # Specific head for this task
+
+    def forward(self, data: Data):
+        node_embeddings = super().forward(data) # Get [num_nodes, dim_h]
+        out = self.node_level_output_head(node_embeddings) # Apply specific head: [num_nodes, 1]
+        return out
+
+class LoSPredictor(GraphGPS):
+    def __init__(self, dim_in, dim_h, num_layers, num_heads, lap_pe_dim, sign_pe_dim, dropout=0.1):
+        super().__init__(dim_in=dim_in, dim_h=dim_h, dim_out_graph_level=1,
+                         num_layers=num_layers, num_heads=num_heads,
+                         lap_pe_dim=lap_pe_dim, sign_pe_dim=sign_pe_dim,
+                         dropout=dropout, local_gnn_type='GATConv', pool_type=None) # No global pooling
+        self.node_level_output_head = nn.Linear(dim_h, 1) # Specific head for this task
+
+    def forward(self, data: Data):
+        node_embeddings = super().forward(data) # Get [num_nodes, dim_h]
+        out = self.node_level_output_head(node_embeddings) # Apply specific head: [num_nodes, 1]
+        return out
+
+if __name__ == '__main__':
+    print("--- Testing models.py (Revised for Node-Level Predictions v2) ---")
+
+    DIM_RAW_FEATURES = 75  # Features from ColumnTransformer in data_utils
+    LAP_PE_K_DIM = 8       # Dimension of LapPE features from data_utils
+    SIGN_PE_K_DIM = 0      # Dimension of SignNet features (0 for now)
+
+    DIM_HIDDEN = 128
+    NUM_GPS_LAYERS = 3
+    NUM_ATTN_HEADS = 4
+    DROPOUT_RATE = 0.1
+
+    print(f"Model Parameters:\n  Raw Features Dim (dim_in for model): {DIM_RAW_FEATURES}")
+    print(f"  LapPE Dim (lap_pe_dim for model): {LAP_PE_K_DIM}")
+    print(f"  SignNet Dim (sign_pe_dim for model): {SIGN_PE_K_DIM}")
+    print(f"  Effective Input Dim to Atom Encoder (dim_raw + lap_pe_dim + sign_pe_dim): {DIM_RAW_FEATURES + LAP_PE_K_DIM + SIGN_PE_K_DIM}")
+    print(f"  Hidden Dim: {DIM_HIDDEN}\n  GPS Layers: {NUM_GPS_LAYERS}\n  Attn Heads: {NUM_ATTN_HEADS}\n  Dropout: {DROPOUT_RATE}")
+
+    num_nodes = 20
+    num_edges = 50
+
+    dummy_x_raw = torch.randn(num_nodes, DIM_RAW_FEATURES)
+    dummy_lap_pe = torch.randn(num_nodes, LAP_PE_K_DIM) if LAP_PE_K_DIM > 0 else None
+
+    dummy_edge_index = torch.randint(0, num_nodes, (2, num_edges))
+    dummy_data = Data(x=dummy_x_raw, edge_index=dummy_edge_index)
+
+    if dummy_lap_pe is not None:
+        dummy_data.lap_pe = dummy_lap_pe
+    # dummy_data.sign_pe will be None if SIGN_PE_K_DIM is 0
+
+    print(f"\nDummy input graph data structure:\n{dummy_data}")
+    print(f"dummy_data.x shape: {dummy_data.x.shape}")
+    if hasattr(dummy_data, 'lap_pe') and dummy_data.lap_pe is not None:
+        print(f"dummy_data.lap_pe shape: {dummy_data.lap_pe.shape}")
+
+
+    print("\n--- Testing MortalityPredictor ---")
+    # dim_in to MortalityPredictor is the dimension of raw features (data.x)
+    # lap_pe_dim is the dimension of data.lap_pe (if present)
+    # sign_pe_dim is the dimension of data.sign_pe (if present)
+    mortality_model = MortalityPredictor(
+        dim_in=DIM_RAW_FEATURES,
+        dim_h=DIM_HIDDEN, num_layers=NUM_GPS_LAYERS, num_heads=NUM_ATTN_HEADS,
+        lap_pe_dim=LAP_PE_K_DIM if dummy_lap_pe is not None else 0,
+        sign_pe_dim=SIGN_PE_K_DIM, # SIGN_PE_K_DIM is 0
+        dropout=DROPOUT_RATE
+    )
+    print(f"Mortality model structure:\n{mortality_model}")
+    try:
+        mortality_output = mortality_model(dummy_data)
+        print(f"Mortality model output shape: {mortality_output.shape}")
+        assert mortality_output.shape == (num_nodes, 1)
+        print(f"Mortality model output sample (first 5):\n{mortality_output[:5]}")
+    except Exception as e:
+        print(f"Error during MortalityPredictor forward pass: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("\n--- Testing LoSPredictor ---")
+    los_model = LoSPredictor(
+        dim_in=DIM_RAW_FEATURES,
+        dim_h=DIM_HIDDEN, num_layers=NUM_GPS_LAYERS, num_heads=NUM_ATTN_HEADS,
+        lap_pe_dim=LAP_PE_K_DIM if dummy_lap_pe is not None else 0,
+        sign_pe_dim=SIGN_PE_K_DIM,
+        dropout=DROPOUT_RATE
+    )
+    print(f"LoS model structure:\n{los_model}")
+    try:
+        los_output = los_model(dummy_data)
+        print(f"LoS model output shape: {los_output.shape}")
+        assert los_output.shape == (num_nodes, 1)
+        print(f"LoS model output sample (first 5):\n{los_output[:5]}")
+    except Exception as e:
+        print(f"Error during LoSPredictor forward pass: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("\n--- Note on Positional Encodings (LapPE & SignNet) ---")
+    print("PEs (if lap_pe_dim > 0 or sign_pe_dim > 0) are now expected to be concatenated to data.x ")
+    print("BEFORE the atom_encoder in the GraphGPS base class.")
+    print("The `dim_in` to GraphGPS constructor should be the dimension of the raw features from data_utils,")
+    print("and `lap_pe_dim`, `sign_pe_dim` should be the dimensions of these PEs as they appear in the Data object.")
+    print("The `atom_encoder` inside GraphGPS will then handle the combined dimension.")
+
+    print("\nmodels.py revised structure and tests complete.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch==2.7.0
+torch_geometric==2.6.1
+pandas
+numpy
+scikit-learn

--- a/train.py
+++ b/train.py
@@ -1,0 +1,308 @@
+import torch
+import torch.optim as optim
+from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
+import torch.nn.functional as F
+from sklearn.metrics import roc_auc_score, mean_squared_error
+import numpy as np
+import pandas as pd
+import os
+import time
+
+from data_utils import load_and_preprocess_data
+from models import MortalityPredictor, LoSPredictor
+
+# --- Configuration ---
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Using device: {DEVICE}")
+
+# Data paths
+TRAIN_CSV = 'data/trainData.csv'
+VAL_CSV = 'data/valData.csv'
+
+# Model Hyperparameters (can be tuned)
+DIM_HIDDEN = 128  # Hidden dimension for GraphGPS
+NUM_GPS_LAYERS = 3
+NUM_ATTN_HEADS = 4
+LAP_PE_K_DIM = 8    # Dimension for Laplacian PE (k eigenvectors)
+SIGN_PE_K_DIM = 0   # Dimension for SignNet features (set to 0 if not using/available)
+DROPOUT_RATE = 0.2 # Increased dropout slightly
+
+# Training Hyperparameters
+LEARNING_RATE = 1e-3
+WEIGHT_DECAY = 1e-5
+EPOCHS = 100 # Max epochs, early stopping will likely intervene
+PATIENCE_EARLY_STOPPING = 15
+COSINE_T_0 = 10 # For CosineAnnealingWarmRestarts: Number of iterations for the first restart.
+COSINE_T_MULT = 2 # For CosineAnnealingWarmRestarts: A factor increases T_i after a restart.
+WARMUP_EPOCHS = 5
+
+# File names for saved models
+MORTALITY_MODEL_PATH = 'model_dt.pt'
+LOS_MODEL_PATH = 'model_los.pt'
+
+# --- Helper Functions ---
+def get_input_dim_from_data(sample_csv_path, lap_pe_k_dim, sign_pe_k_dim):
+    """
+    Infers the input dimension by preprocessing a small sample of data.
+    This is crucial because the number of features can change based on one-hot encoding.
+    """
+    print("Inferring input dimension from sample data...")
+    # Load a small part of data to get feature dimension after preprocessing
+    # No need to fit preprocessor here if it's already done, but we need its output shape
+    # For safety, we'll create a throwaway preprocessor on a small slice if one isn't provided
+    # However, the main function will fit it on full train and pass it.
+    # This function is more of a utility if you need dim_in *before* full data loading.
+
+    # Re-using the main data loading logic for consistency
+    graph_data_sample, _, preprocessor_sample = load_and_preprocess_data(
+        sample_csv_path,
+        fit_preprocessor=True, # Fit a temporary preprocessor
+        target_cols=None,      # Not needed for dim inference
+        k_neighbors=3          # Small k, not relevant for feature dim
+    )
+    if graph_data_sample is None or preprocessor_sample is None:
+        raise RuntimeError("Failed to process sample data for dimension inference.")
+
+    dim_in = graph_data_sample.x.shape[1]
+    print(f"Inferred input dimension (features + PEs): {dim_in}") # This dim already includes PE from AddLaplacianEigenvectorPE
+
+    # The current data_utils.py adds LapPE *after* ColumnTransformer.
+    # The model's atom_encoder expects raw features, PEs are added separately inside the model.
+    # So, we need the dimension *before* PEs are added by the transform, then add PE dims in model constructor.
+
+    # Let's get the dimension from the preprocessor directly
+    num_numerical_features = len(preprocessor_sample.transformers_[0][2])
+
+    cat_transformer = preprocessor_sample.named_transformers_['cat']
+    onehot_encoder = cat_transformer.named_steps['onehot']
+    num_onehot_features = 0
+    if hasattr(onehot_encoder, 'get_feature_names_out'):
+        num_onehot_features = len(onehot_encoder.get_feature_names_out(preprocessor_sample.transformers_[1][2]))
+    elif hasattr(onehot_encoder, 'categories_'):
+        for cats in onehot_encoder.categories_:
+            num_onehot_features += len(cats)
+
+    dim_processed_features = num_numerical_features + num_onehot_features
+    print(f"Dimension from preprocessor (numerical + one-hot categorical): {dim_processed_features}")
+    return dim_processed_features
+
+
+def train_model(model, train_data, val_data, criterion, optimizer, scheduler,
+                task_name, epochs, patience, model_path):
+    best_val_metric = -np.inf if task_name == "Mortality" else np.inf
+    epochs_no_improve = 0
+
+    print(f"\n--- Starting Training: {task_name} ---")
+    print(f"Model: {model.__class__.__name__}")
+    print(f"Optimizer: {optimizer}")
+    print(f"Scheduler: {scheduler.__class__.__name__ if scheduler else 'None'}")
+    print(f"Criterion: {criterion}")
+
+    for epoch in range(1, epochs + 1):
+        start_time = time.time()
+        model.train()
+        optimizer.zero_grad()
+
+        # Assuming train_data is a single Data object for the entire training graph
+        out = model(train_data.to(DEVICE))
+
+        if task_name == "Mortality":
+            target = train_data.y_mortality.to(DEVICE)
+            loss = criterion(out, target)
+        elif task_name == "LoS":
+            # Apply log transform to target for LoS as specified
+            target = torch.log1p(train_data.y_los.to(DEVICE)) # log1p for stability (log(x+1))
+            loss = criterion(out, target)
+        else:
+            raise ValueError("Unknown task name")
+
+        loss.backward()
+        optimizer.step()
+
+        if scheduler and epoch > WARMUP_EPOCHS: # Apply scheduler after warmup
+             if isinstance(scheduler, CosineAnnealingWarmRestarts):
+                scheduler.step(epoch - WARMUP_EPOCHS)
+             else: # For other schedulers like ReduceLROnPlateau
+                # Evaluation needed for ReduceLROnPlateau, handled below
+                pass
+
+        # Evaluation
+        model.eval()
+        with torch.no_grad():
+            val_out = model(val_data.to(DEVICE))
+            if task_name == "Mortality":
+                val_target = val_data.y_mortality.to(DEVICE)
+                val_loss = criterion(val_out, val_target)
+                # Apply sigmoid for AUROC calculation
+                val_probs = torch.sigmoid(val_out).cpu().numpy()
+                val_metric = roc_auc_score(val_target.cpu().numpy(), val_probs)
+                metric_name = "AUROC"
+            elif task_name == "LoS":
+                val_target_log = torch.log1p(val_data.y_los.to(DEVICE))
+                val_loss = criterion(val_out, val_target_log)
+                # Inverse transform for RMSE: exp(preds) - 1
+                val_preds_original_scale = torch.expm1(val_out).cpu().numpy()
+                val_target_original_scale = val_data.y_los.cpu().numpy()
+                val_metric = np.sqrt(mean_squared_error(val_target_original_scale, val_preds_original_scale.clip(min=0)))
+                metric_name = "RMSE"
+
+        epoch_duration = time.time() - start_time
+        print(f"Epoch {epoch}/{epochs} | Train Loss: {loss.item():.4f} | Val Loss: {val_loss.item():.4f} | Val {metric_name}: {val_metric:.4f} | LR: {optimizer.param_groups[0]['lr']:.6f} | Time: {epoch_duration:.2f}s")
+
+        if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+            scheduler.step(val_metric if task_name == "Mortality" else val_loss) # AUROC higher is better, RMSE lower is better
+
+        # Early stopping and model saving
+        if task_name == "Mortality": # Higher is better for AUROC
+            if val_metric > best_val_metric:
+                best_val_metric = val_metric
+                torch.save(model.state_dict(), model_path)
+                print(f"Improved {metric_name}. Model saved to {model_path}")
+                epochs_no_improve = 0
+            else:
+                epochs_no_improve += 1
+        else: # Lower is better for RMSE
+            if val_metric < best_val_metric:
+                best_val_metric = val_metric
+                torch.save(model.state_dict(), model_path)
+                print(f"Improved {metric_name}. Model saved to {model_path}")
+                epochs_no_improve = 0
+            else:
+                epochs_no_improve += 1
+
+        if epochs_no_improve >= patience:
+            print(f"Early stopping triggered after {patience} epochs with no improvement.")
+            break
+
+    print(f"Finished training for {task_name}. Best Val {metric_name}: {best_val_metric:.4f}")
+    model.load_state_dict(torch.load(model_path)) # Load best model
+    return model
+
+# --- Main Training Execution ---
+if __name__ == "__main__":
+    print("Starting main training script execution...")
+
+    # Infer input dimension from data (IMPORTANT: ensure this matches model's dim_in)
+    # This requires preprocessing a small part of the data to know the number of features
+    # after one-hot encoding etc.
+    # The `dim_in` for the GraphGPS model should be the number of node features *before* LapPE/SignNet
+    # are added within the model, as the model has separate encoders for them.
+
+    # We need to load data first to get the preprocessor and the shape of X *after* ColumnTransformer
+    print("Loading and preprocessing training data for dimension inference and training...")
+    train_graph, train_targets_df, preprocessor = load_and_preprocess_data(
+        TRAIN_CSV,
+        fit_preprocessor=True,
+        target_cols=['outcomeType', 'lengthofStay'],
+        k_neighbors=10 # As per document
+    )
+    if train_graph is None:
+        print("Failed to load training data. Exiting.")
+        exit()
+
+    # The number of features from the ColumnTransformer output
+    # This is before LapPE is added by the PyG transform if AddLaplacianEigenvectorPE is used *after*
+    # But our current data_utils.py applies AddLaplacianEigenvectorPE *inside* load_and_preprocess_data
+    # and stores it as 'lap_pe'. The model then uses this attribute.
+    # So, data.x from data_utils should be the features *before* PEs are explicitly added by model.
+    # The model's atom_encoder will take data.x
+    # The model's pe_encoders will take data.lap_pe and data.sign_pe
+
+    # Let's adjust dim_in to be the number of features from the preprocessor,
+    # and the model internally handles adding PE dimensions.
+
+    # Get the number of features output by the ColumnTransformer
+    # This is the actual input dimension to the model's self.atom_encoder
+    num_numerical_features_fitted = len(preprocessor.transformers_[0][2])
+    cat_transformer_fitted = preprocessor.named_transformers_['cat']
+    onehot_encoder_fitted = cat_transformer_fitted.named_steps['onehot']
+    num_onehot_features_fitted = 0
+    if hasattr(onehot_encoder_fitted, 'get_feature_names_out'):
+        num_onehot_features_fitted = len(onehot_encoder_fitted.get_feature_names_out(preprocessor.transformers_[1][2]))
+    elif hasattr(onehot_encoder_fitted, 'categories_'): # Fallback for older sklearn
+        for cats in onehot_encoder_fitted.categories_:
+            num_onehot_features_fitted += len(cats)
+
+    DIM_IN_FEATURES_FROM_DATA = num_numerical_features_fitted + num_onehot_features_fitted
+    print(f"Actual input dimension from preprocessed data (excluding explicit PEs): {DIM_IN_FEATURES_FROM_DATA}")
+
+    # Check if lap_pe was added by data_utils and its dimension
+    actual_lap_pe_dim = 0
+    if hasattr(train_graph, 'lap_pe') and train_graph.lap_pe is not None:
+        actual_lap_pe_dim = train_graph.lap_pe.shape[1]
+        print(f"LapPE found in data with dimension: {actual_lap_pe_dim}")
+        if actual_lap_pe_dim != LAP_PE_K_DIM:
+            print(f"WARNING: LAP_PE_K_DIM ({LAP_PE_K_DIM}) in train script config differs from actual LapPE dim ({actual_lap_pe_dim}) in data. Using actual: {actual_lap_pe_dim}")
+            # LAP_PE_K_DIM = actual_lap_pe_dim # Use the dimension from data
+    else:
+        print("No LapPE found in data. lap_pe_dim will be effectively 0 for the model if not provided.")
+        LAP_PE_K_DIM = 0 # Ensure model knows no LapPE is coming if not in data.
+
+    # SIGN_PE_K_DIM is already 0 by default. If it were > 0, we'd need data.sign_pe
+
+    print("Loading and preprocessing validation data...")
+    val_graph, val_targets_df = load_and_preprocess_data(
+        VAL_CSV,
+        preprocessor=preprocessor,
+        fit_preprocessor=False,
+        target_cols=['outcomeType', 'lengthofStay'],
+        k_neighbors=10
+    )
+    if val_graph is None:
+        print("Failed to load validation data. Exiting.")
+        exit()
+
+    # --- Train Mortality Model ---
+    print("\nInitializing Mortality Predictor...")
+    mortality_model = MortalityPredictor(
+        dim_in=DIM_IN_FEATURES_FROM_DATA,  # Features from ColumnTransformer
+        dim_h=DIM_HIDDEN,
+        num_layers=NUM_GPS_LAYERS,
+        num_heads=NUM_ATTN_HEADS,
+        lap_pe_dim=actual_lap_pe_dim, # Dimension of LapPE provided in Data object
+        sign_pe_dim=SIGN_PE_K_DIM,  # Dimension of SignNet PE provided in Data object
+        dropout=DROPOUT_RATE
+    ).to(DEVICE)
+
+    # Weighted BCE loss for imbalanced classification
+    # Calculate pos_weight for mortality
+    if train_graph.y_mortality is not None:
+        num_positive = torch.sum(train_graph.y_mortality == 1)
+        num_negative = torch.sum(train_graph.y_mortality == 0)
+        pos_weight_value = num_negative / (num_positive + 1e-6) # Add epsilon to avoid division by zero
+        print(f"Mortality: Negatives={num_negative}, Positives={num_positive}, Pos_weight={pos_weight_value:.2f}")
+        criterion_mortality = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([pos_weight_value], device=DEVICE))
+    else:
+        print("Warning: y_mortality not found in train_graph. Using unweighted BCEWithLogitsLoss.")
+        criterion_mortality = nn.BCEWithLogitsLoss()
+
+    optimizer_mortality = optim.AdamW(mortality_model.parameters(), lr=LEARNING_RATE, weight_decay=WEIGHT_DECAY)
+    scheduler_mortality = CosineAnnealingWarmRestarts(optimizer_mortality, T_0=COSINE_T_0, T_mult=COSINE_T_MULT)
+
+    mortality_model = train_model(mortality_model, train_graph, val_graph, criterion_mortality,
+                                  optimizer_mortality, scheduler_mortality, "Mortality",
+                                  EPOCHS, PATIENCE_EARLY_STOPPING, MORTALITY_MODEL_PATH)
+
+    # --- Train LoS Model ---
+    print("\nInitializing LoS Predictor...")
+    los_model = LoSPredictor(
+        dim_in=DIM_IN_FEATURES_FROM_DATA, # Features from ColumnTransformer
+        dim_h=DIM_HIDDEN,
+        num_layers=NUM_GPS_LAYERS,
+        num_heads=NUM_ATTN_HEADS,
+        lap_pe_dim=actual_lap_pe_dim, # Dimension of LapPE provided in Data object
+        sign_pe_dim=SIGN_PE_K_DIM,  # Dimension of SignNet PE provided in Data object
+        dropout=DROPOUT_RATE
+    ).to(DEVICE)
+
+    criterion_los = nn.MSELoss() # Target will be log-transformed
+    optimizer_los = optim.AdamW(los_model.parameters(), lr=LEARNING_RATE, weight_decay=WEIGHT_DECAY)
+    scheduler_los = CosineAnnealingWarmRestarts(optimizer_los, T_0=COSINE_T_0, T_mult=COSINE_T_MULT)
+
+    los_model = train_model(los_model, train_graph, val_graph, criterion_los,
+                            optimizer_los, scheduler_los, "LoS",
+                            EPOCHS, PATIENCE_EARLY_STOPPING, LOS_MODEL_PATH)
+
+    print("\nTraining finished. Models saved to:")
+    print(f"Mortality Model: {MORTALITY_MODEL_PATH}")
+    print(f"LoS Model: {LOS_MODEL_PATH}")


### PR DESCRIPTION
- Modified GraphGPS base model to correctly handle positional encodings concatenated to input features before a single atom_encoder.
- Ensured that for node-level prediction tasks (MortalityPredictor, LoSPredictor), the GraphGPS base returns node embeddings [num_nodes, dim_h].
- Specialized predictor classes now apply their own output_head to these node embeddings, ensuring the output shape is [num_nodes, 1], matching the target tensor shapes for loss calculation.
- Updated `if __name__ == '__main__'` in models.py to reflect these changes and test the correct output shapes.